### PR TITLE
patch/fix-deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Deploy to Pages
+name: Deploy
 
 on:
   workflow_dispatch:

--- a/src/theme/Switch/colorMode/index.ts
+++ b/src/theme/Switch/colorMode/index.ts
@@ -5,17 +5,27 @@ const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpe
   switchAnatomy.keys,
 );
 
+const SUN_URL = `${import.meta.env.BASE_URL}/sun.svg`;
+const MOON_URL = `${import.meta.env.BASE_URL}/moon.svg`;
+
 /**
  * custom variant for the Chakra Switch component that holds sun and moon svg elements
+ *
  * Note: to avoid a 'hiccup' in rendering while the browser fetches the other svg, use the public dir
- * https://vitejs.dev/guide/assets.html#the-public-directory
  * this way both svgs are cached immediately
+ *
+ * Note: when using a base url (like for github pages) need vite's globally injected
+ * import.meta.env.BASE_URL var so that both dev and prod can use
+ *
+ * https://vitejs.dev/guide/assets.html#the-public-directory
+ *
+ * https://vitejs.dev/guide/build.html#public-base-path
  */
 const colorMode = definePartsStyle({
   thumb: {
     bgColor: 'goldenrod',
-    maskImage: 'url("/sun.svg")',
-    WebkitMaskImage: 'url("/sun.svg")',
+    maskImage: `url(${SUN_URL})`,
+    WebkitMaskImage: `url(${SUN_URL})`,
     maskPosition: 'center',
     maskRepeat: 'no-repeat',
     maskSize: 'cover',
@@ -23,8 +33,8 @@ const colorMode = definePartsStyle({
     // if checked, dark mode enabled
     _dark: { bgColor: `whiteAlpha.800` },
     _checked: {
-      maskImage: 'url("/moon.svg")',
-      WebkitMaskImage: 'url("/moon.svg")',
+      maskImage: `url(${MOON_URL})`,
+      WebkitMaskImage: `url(${MOON_URL})`,
       transform: `translateX(var(--switch-thumb-x)) scaleX(${-1})`, // flip
     },
   },


### PR DESCRIPTION
update css url paths with vite's globally injected `import.meta.env.BASE_URL` var so that both dev and prod can find svg assets